### PR TITLE
Fix active state of header links

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,8 +13,8 @@ const { showingShort } = Astro.props
 
 const books = await getCollection("books");
 
-const pathname = new URL(Astro.request.url).pathname;
-const currentPath = pathname.slice(1);
+// Remove leading and trailing slashes from pathname to get a consistent comparison across environments
+const currentPath = Astro.url.pathname.replace(/^\/|\/$/g, "");
 
 ---
 


### PR DESCRIPTION
Fixes https://mastodon.social/@marcel/111716620610101276

The reason for the problem is that when Astro generates the static site, it generates `/your-path/index.html` files. In these circumstances, `pathname` is `/your-path/` (with trailing slash). Your current code only removes the leading slash, but not the trailing one.

I changed two things:

- Replaced the `new URL(Astro.request.url)` shenanigans with `Astro.url.pathname` (see docs here: https://docs.astro.build/de/reference/api-reference/#astrourl) 
- Used a Regex to remove leading and trailing slashes _if they exist_. I couldn't keep using `slice` for that, because then it would break in development.